### PR TITLE
Fix Etsy slug hyphen

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       <h2>Pricing</h2>
       <p>Move-In/Out Kit $12 · Lease Pack $29 · Bundle $35</p>
       <div class="product-links">
-        <a href="#" class="btn" rel="noopener noreferrer">Buy Bundle</a>
+        <a href="https://www.etsy.com/listing/byu-uvu-move" class="btn" rel="noopener noreferrer">Buy Bundle</a>
       </div>
     </div>
   </section>

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const html = fs.readFileSync('index.html', 'utf8');
 
 // Extract the content of the first element with class "product-links"
-const productLinksMatch = html.match(/<[^>]*class=["'][^"']*product-links[^"']*["'][^>]*>([\s\S]*?)<\/[^>]+>/i);
+const productLinksMatch = html.match(/<[^>]*class=["'][^"']*product-links[^"']*["'][^>]*>([\s\S]*?)<\/div>/i);
 const productLinksContent = productLinksMatch ? productLinksMatch[1] : '';
 
 // Find all anchor opening and closing tags within the section


### PR DESCRIPTION
## Summary
- link to Etsy listing now uses correct `byu-uvu-move` slug
- fix product link test to capture section until closing div

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f9ee504c832ca0154181c50ed5eb