### PR TITLE
Fix product-links anchor test

### DIFF
--- a/test.js
+++ b/test.js
@@ -5,7 +5,9 @@ const assert = require('assert');
 const html = fs.readFileSync('index.html', 'utf8');
 
 // Extract the content of the first element with class "product-links"
-const productLinksMatch = html.match(/<[^>]*class=["'][^"']*product-links[^"']*["'][^>]*>([\s\S]*?)<\/[^>]+>/i);
+const productLinksMatch = html.match(
+  /<[^>]*class=["'][^"']*product-links[^"']*["'][^>]*>([\s\S]*?)<\/div>/i
+);
 const productLinksContent = productLinksMatch ? productLinksMatch[1] : '';
 
 // Find all anchor opening and closing tags within the section


### PR DESCRIPTION
## Summary
- Update product-links regex to match up to closing div, ensuring the test inspects only the intended section.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f9f209e0832cb528f6f70095ffad