### PR TITLE
Add real links for landlord kit page

### DIFF
--- a/provo-student-landlord-kits.html
+++ b/provo-student-landlord-kits.html
@@ -60,10 +60,10 @@
   <!-- Update your links here -->
   <script>
     const LINKS = {
-      moveInOut: "#",     // ← paste Gumroad/Etsy link
-      leasePack: "#",     // ← paste Gumroad/Etsy link
-      bundle: "#",        // ← paste bundle link
-      email: "mailto:you@example.com"
+      moveInOut: "https://example.com/move-in-out-kit",     // ← paste Gumroad/Etsy link
+      leasePack: "https://example.com/room-lease-pack",     // ← paste Gumroad/Etsy link
+      bundle: "https://example.com/bundle",        // ← paste bundle link
+      email: "mailto:info@example.com"
     };
     document.addEventListener("DOMContentLoaded", () => {
       for (const [k,v] of Object.entries(LINKS)) {


### PR DESCRIPTION
## Summary
- Replace placeholder links with example URLs and contact email in `provo-student-landlord-kits.html`
- Confirm runtime script injects hrefs into all `data-link` anchors

## Testing
- `node - <<'NODE' ...` (jsdom) to verify anchor href injection
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba000c5724832c999f5a4a1299b334