### PR TITLE
Remove outdated coupon references

### DIFF
--- a/provo-student-landlord-kits.html
+++ b/provo-student-landlord-kits.html
@@ -236,7 +236,6 @@
             <ul class="clean" style="margin-top:8px">
               <li><svg class="check" aria-hidden="true" focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>Everything in both kits</li>
               <li><svg class="check" aria-hidden="true" focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>One checkout • instant access</li>
-              <li><svg class="check" aria-hidden="true" focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>Coupon ready (use UT10OFF if active)</li>
             </ul>
             <a data-link="bundle" class="btn block" style="margin-top:12px">Get Bundle $35</a>
           </div>
@@ -298,7 +297,6 @@
         <a data-link="leasePack" class="btn secondary">Lease Pack $29</a>
         <a data-link="bundle" class="btn">Bundle $35</a>
       </div>
-      <div class="tiny" style="margin-top:8px">Use coupon <strong>UT10OFF</strong> if it’s still active.</div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Remove UT10OFF coupon line from Starter Bundle list
- Drop CTA coupon note when no valid code is available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb5de9fa48832ca61f661459c8b7c9