### PR TITLE
Track Facebook conversion on buy links

### DIFF
--- a/index.html
+++ b/index.html
@@ -554,6 +554,22 @@
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
+  <script>
+    const buyLinks = document.querySelectorAll(
+      'a[href="https://www.etsy.com/listing/4360689808/byuuvu-move-inout-kit-checklist-roommate"]'
+    );
+
+    buyLinks.forEach(link => {
+      link.addEventListener('click', () => {
+        fbq('track', 'Purchase', {
+          value: 35.00,
+          currency: 'USD',
+          content_name: 'Roommate Lease & Move-In/Out Bundle',
+          event_source: 'BuyButton'
+        });
+      });
+    });
+  </script>
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- send a Meta Pixel Purchase event whenever any Buy button is clicked

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68cb8fdef6d4832c854aabca1ef4ef67